### PR TITLE
Smart Cursor bug fixes

### DIFF
--- a/SmartCursor/src/ModEntry.cs
+++ b/SmartCursor/src/ModEntry.cs
@@ -270,13 +270,16 @@ namespace SmartCursor
             GamePadState gamepadState = Game1.input.GetGamePadState();
             MouseState mouseState = Game1.input.GetMouseState();
 
+            if (this.isHoldKeyDown)
+                this.Helper.Input.Suppress(SButton.MouseRight);
+
             // Now, if our cooldown timer has passed and the correct keys are held, we want to hit again.
             if (this.isHoldKeyDown && (gamepadState.IsButtonDown(Buttons.X)
                                        || mouseState.LeftButton == ButtonState.Pressed) && !Game1.player.UsingTool)
             {
                 // if (Game1.player.UsingTool)
                 //     return;
-                Game1.player.UsingTool = true;
+                // Game1.player.UsingTool = true;
 
                 var dummy = new Farmer();
 
@@ -287,13 +290,15 @@ namespace SmartCursor
                     this.GatherResources(Game1.currentLocation);
                 }
 
-                Game1.player.EndUsingTool();
+                // Game1.player.EndUsingTool();
             }
         }
 
         private void BreakObject(Farmer player, Tool tool, bool refundStamina)
         {
             float startingStamina = player.stamina;
+
+            player.BeginUsingTool();
 
             tool.DoFunction(
                 Game1.currentLocation,
@@ -510,6 +515,9 @@ namespace SmartCursor
 
             var dummy = new Farmer();
             this.isHoldKeyDown = e.IsDown(this.config.SmartCursorHold);
+
+            if (this.isHoldKeyDown)
+                this.Helper.Input.Suppress(SButton.MouseRight);
 
             if ((e.Button == SButton.MouseLeft || e.Button == SButton.ControllerX ||
                  Game1.input.GetMouseState().LeftButton == ButtonState.Pressed) && !Game1.player.UsingTool)


### PR DESCRIPTION
## Player animation freeze

`Game1.player.UsingTool` never seemed to reset after manually setting it to `true`, even after calling `Game1.player.EndUsingTool()`. This caused an infinite loop of the game thinking that the player is using a tool, even after the animation had finished.

I was able to consistently replicate this bug by either holding a scythe or nothing, then holding the keybind, and finally just holding the left mouse button.

I used `player.BeginUsingTool()` in the `BreakObject` method, which seems to have solved the issue.

## Tool spam usage

When holding the keybind and the left mouse button to use a tool, you could spam click the right mouse button to constantly reset the animation, allowing for much faster (and unintended?) tool usage.

It sounds like a bug to me, so I suppressed the right mouse button while the keybind is held.