### PR TITLE
Allow for upgrade level to be higher than the dictionary index

### DIFF
--- a/SmartCursor/src/ModEntry.cs
+++ b/SmartCursor/src/ModEntry.cs
@@ -347,8 +347,10 @@ namespace SmartCursor
                     break;
             }
 
+            int upgradeLevel = player.CurrentTool.UpgradeLevel < 7 ? player.CurrentTool.UpgradeLevel : 6;
+
             return this.GetTileToTarget(playerTile, breakableType, this.breakableResources,
-                this.toolRanges[player.CurrentTool.UpgradeLevel] + 1f);
+                this.toolRanges[upgradeLevel] + 1f);
         }
 
         /// <summary>


### PR DESCRIPTION
The dictionary index was throwing an exception when using with the Prismatic Tools mod.  Not sure this is the ideal fix, but it'll at least avoid issues with mods that might add higher upgrade levels.