### PR TITLE
MEEP: Finally fix theoretically impossible animal null reference.

### DIFF
--- a/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
+++ b/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
@@ -8,7 +8,7 @@
         <Description>Extra map features and tile/map properties to spice up your custom maps.</Description>
         <MinimumApiVersion>4.0.0</MinimumApiVersion>
         <UpdateKeys>Nexus:14493</UpdateKeys>
-        <Version>2.4.4</Version>
+        <Version>2.4.5-test</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
+++ b/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
@@ -8,7 +8,7 @@
         <Description>Extra map features and tile/map properties to spice up your custom maps.</Description>
         <MinimumApiVersion>4.0.0</MinimumApiVersion>
         <UpdateKeys>Nexus:14493</UpdateKeys>
-        <Version>2.4.4</Version>
+        <Version>2.4.5</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -26,6 +26,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 </Project>

--- a/MappingExtensionsAndExtraProperties/src/Features/FarmAnimalSpawnsFeature.cs
+++ b/MappingExtensionsAndExtraProperties/src/Features/FarmAnimalSpawnsFeature.cs
@@ -252,7 +252,7 @@ public class FarmAnimalSpawnsFeature : Feature
             if (is_auto_pet)
                 return true;
 
-            if (who is null || who.currentLocation is null)
+            if (who is null || who.currentLocation is null || __instance.currentLocation is null || __instance.currentLocation.Name is null)
                 return true;
 
             if (who.currentLocation.Name != __instance.currentLocation.Name)

--- a/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
+++ b/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "MEEP Tile Property Test Mod",
     "Author": "DecidedlyHuman",
-    "Version": "2.4.2",
+    "Version": "2.4.5",
     "Description": "Tile properties for testing.",
     "UniqueID": "meep.test",
     "UpdateKeys": [],

--- a/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
+++ b/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "MEEP Tile Property Test Mod",
     "Author": "DecidedlyHuman",
-    "Version": "2.4.2",
+    "Version": "2.4.5-test",
     "Description": "Tile properties for testing.",
     "UniqueID": "meep.test",
     "UpdateKeys": [],


### PR DESCRIPTION
It's apparently possible for an animal's location to be null, despite the animal existing in the world.