### PR TITLE
Work around vanilla bug regarding farmhouse animal deletion.

### DIFF
--- a/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
+++ b/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\DecidedlyShared\DecidedlyShared.projitems" Label="Shared" />
 
     <PropertyGroup>
@@ -6,7 +6,7 @@
         <Description>Extra map features and tile/map properties to spice up your custom maps.</Description>
         <MinimumApiVersion>4.0.0</MinimumApiVersion>
         <UpdateKeys>Nexus:14493</UpdateKeys>
-        <Version>2.5.2</Version>
+        <Version>2.5.2-beta.1</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
+++ b/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
@@ -6,7 +6,7 @@
         <Description>Extra map features and tile/map properties to spice up your custom maps.</Description>
         <MinimumApiVersion>4.0.0</MinimumApiVersion>
         <UpdateKeys>Nexus:14493</UpdateKeys>
-        <Version>2.5.2-beta.1</Version>
+        <Version>2.5.2</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
+++ b/MappingExtensionsAndExtraProperties/MappingExtensionsAndExtraProperties.csproj
@@ -6,7 +6,7 @@
         <Description>Extra map features and tile/map properties to spice up your custom maps.</Description>
         <MinimumApiVersion>4.0.0</MinimumApiVersion>
         <UpdateKeys>Nexus:14493</UpdateKeys>
-        <Version>2.5.1</Version>
+        <Version>2.5.2</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/MappingExtensionsAndExtraProperties/src/Features/FarmAnimalSpawnsFeature.cs
+++ b/MappingExtensionsAndExtraProperties/src/Features/FarmAnimalSpawnsFeature.cs
@@ -317,23 +317,6 @@ public class FarmAnimalSpawnsFeature : Feature
 
         logger.Log($"Spawned {this.animalsSpawned} animals. This is normal, and will not cause or result in lag.", LogLevel.Trace);
         logger.Log("Done with this DayStart event.", LogLevel.Trace);
-
-        // foreach (GameLocation location in Game1.locations)
-        // {
-        //     foreach (FarmAnimal animal in location.animals.Values)
-        //     {
-        //         if (animal.modData.ContainsKey("MEEP_Farm_Animal_ID"))
-        //         {
-        //             logger.Log($"Location: {location.Name}", LogLevel.Info);
-        //
-        //             foreach (string s in animal.modData.Values)
-        //                 logger.Log($"Animal {animal.Name} modData: {s}", LogLevel.Info);
-        //
-        //             logger.Log($"Animal {animal.Name} X: {animal.Position.X}", LogLevel.Info);
-        //             logger.Log($"Animal {animal.Name} Y: {animal.Position.Y}", LogLevel.Info);
-        //         }
-        //     }
-        // }
     }
 
     public override bool ShouldChangeCursor(GameLocation location, int tileX, int tileY, out int cursorId)

--- a/MappingExtensionsAndExtraProperties/src/Features/FarmAnimalSpawnsFeature.cs
+++ b/MappingExtensionsAndExtraProperties/src/Features/FarmAnimalSpawnsFeature.cs
@@ -79,6 +79,10 @@ public class FarmAnimalSpawnsFeature : Feature
         }
 
         this.Enabled = true;
+
+        // This is necessary in order to have animals spawn on the first day, since we otherwise
+        // add this on day end.
+        Game1.addMorningFluffFunction(this.DayStartAction);
     }
 
     public override void Disable()
@@ -88,7 +92,6 @@ public class FarmAnimalSpawnsFeature : Feature
 
     public override void RegisterCallbacks()
     {
-        FeatureManager.OnDayStartCallback += this.OnDayStart;
         FeatureManager.EarlyDayEndingCallback += this.OnEarlyDayEnding;
         FeatureManager.OnDisplayRenderedCallback += this.OnDisplayRenderedCallback;
     }
@@ -139,9 +142,12 @@ public class FarmAnimalSpawnsFeature : Feature
         });
 
         if (this.animalsRemoved != this.animalsSpawned)
-            logger.Log("MEEP didn't remove as many animals as were spawned. There will likely be a warning about duplicates after this. Please upload this log to https://smapi.io and report this.", LogLevel.Warn);
+            logger.Log("MEEP didn't remove as many animals as were spawned. There will likely be a warning about duplicates after this. Please upload this log to https://smapi.io and report this if you notice any problems.", LogLevel.Trace);
 
         this.animalsRemoved = 0;
+
+        // This is a workaround for a vanilla bug.
+        Game1.addMorningFluffFunction(this.DayStartAction);
     }
 
     private void RemoveFarmAnimal(FarmAnimal animal)
@@ -174,19 +180,17 @@ public class FarmAnimalSpawnsFeature : Feature
         }
         catch (Exception e)
         {
-            logger.Log($"Ran into a problem removing animal {animal.Name}");
+            logger.Log($"Ran into a problem removing animal {animal.Name}", LogLevel.Warn);
         }
     }
 
-    private void OnDayStart(object? sender, EventArgs e)
+    private void DayStartAction()
     {
         if (!Context.IsWorldReady || !Context.IsMainPlayer || !this.Enabled)
             return;
 
         if (FarmAnimalSpawnsFeature.quickSaveApi is not null)
         {
-            logger.Log("Quick Save's API was loaded properly.", LogLevel.Trace);
-
             if (FarmAnimalSpawnsFeature.quickSaveApi.IsLoading)
             {
                 logger.Log("Quick Save indicated it was loading. Skipping this DayStart.", LogLevel.Trace);
@@ -267,7 +271,7 @@ public class FarmAnimalSpawnsFeature : Feature
                         {
                             logger.Error(
                                 $"Animal {babbyAnimal.Name} already exists with MEEP id {id} in {targetLocation.Name}. This means removal failed to happen for some reason. Attempting to fix it automatically.");
-                                glitchedAnimals.Add(existingAnimal);
+                            glitchedAnimals.Add(existingAnimal);
                         }
                         else if (string.IsNullOrWhiteSpace(id))
                         {
@@ -306,13 +310,30 @@ public class FarmAnimalSpawnsFeature : Feature
             }
             catch (Exception ex)
             {
-                logger.Log($"Caught an exception spawning {animal.Value.AnimalId} spawned in {animal.Value.LocationId}. Skipping!");
+                logger.Log($"Caught an exception spawning {animal.Value.AnimalId} spawned in {animal.Value.LocationId}. Skipping!", LogLevel.Error);
                 logger.Exception(ex);
             }
         }
 
         logger.Log($"Spawned {this.animalsSpawned} animals. This is normal, and will not cause or result in lag.", LogLevel.Trace);
         logger.Log("Done with this DayStart event.", LogLevel.Trace);
+
+        // foreach (GameLocation location in Game1.locations)
+        // {
+        //     foreach (FarmAnimal animal in location.animals.Values)
+        //     {
+        //         if (animal.modData.ContainsKey("MEEP_Farm_Animal_ID"))
+        //         {
+        //             logger.Log($"Location: {location.Name}", LogLevel.Info);
+        //
+        //             foreach (string s in animal.modData.Values)
+        //                 logger.Log($"Animal {animal.Name} modData: {s}", LogLevel.Info);
+        //
+        //             logger.Log($"Animal {animal.Name} X: {animal.Position.X}", LogLevel.Info);
+        //             logger.Log($"Animal {animal.Name} Y: {animal.Position.Y}", LogLevel.Info);
+        //         }
+        //     }
+        // }
     }
 
     public override bool ShouldChangeCursor(GameLocation location, int tileX, int tileY, out int cursorId)

--- a/MappingExtensionsAndExtraProperties/src/ModEntry.cs
+++ b/MappingExtensionsAndExtraProperties/src/ModEntry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using DecidedlyShared.APIs;
 using DecidedlyShared.Logging;
 using DecidedlyShared.Utilities;
@@ -66,6 +67,35 @@ public class ModEntry : Mod
 
         helper.Events.Player.Warped += this.PlayerOnWarped;
         helper.Events.GameLoop.DayStarted += this.OnDayStarted;
+
+        this.AddDebugKeybinds();
+    }
+
+    [Conditional("DEBUG")]
+    private void AddDebugKeybinds()
+    {
+        this.Helper.Events.Input.ButtonPressed += this.OnDebugButtonPressed;
+    }
+
+    private void OnDebugButtonPressed(object? sender, ButtonPressedEventArgs e)
+    {
+        // Welcome to hot reload city. Population: me.
+
+        if (e.Button == SButton.OemSemicolon)
+        {
+            this.logger.Log($"Printing info of all animals in {Game1.currentLocation.Name}.", LogLevel.Info);
+
+            foreach (FarmAnimal animal in Game1.currentLocation.animals.Values)
+            {
+                this.logger.Log($"{animal.Name} X: {animal.Position.X}.", LogLevel.Info);
+                this.logger.Log($"{animal.Name} Y: {animal.Position.Y}.", LogLevel.Info);
+
+                foreach (string s in animal.modData.Values)
+                {
+                    this.logger.Log($"{animal.Name} modData: {s}", LogLevel.Info);
+                }
+            }
+        }
     }
 
     private void LoadContentPacks()

--- a/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
+++ b/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "MEEP Tile Property Test Mod",
     "Author": "DecidedlyHuman",
-    "Version": "2.5.2",
+    "Version": "2.5.2-beta.1",
     "Description": "Tile properties for testing.",
     "UniqueID": "meep.test",
     "UpdateKeys": [],

--- a/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
+++ b/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "MEEP Tile Property Test Mod",
     "Author": "DecidedlyHuman",
-    "Version": "2.5.2-beta.1",
+    "Version": "2.5.2",
     "Description": "Tile properties for testing.",
     "UniqueID": "meep.test",
     "UpdateKeys": [],

--- a/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
+++ b/MappingExtensionsAndExtraProperties/test-pack/TilePropertyMod/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "MEEP Tile Property Test Mod",
     "Author": "DecidedlyHuman",
-    "Version": "2.5.1",
+    "Version": "2.5.2",
     "Description": "Tile properties for testing.",
     "UniqueID": "meep.test",
     "UpdateKeys": [],


### PR DESCRIPTION
Moves all MEEP farm animal spawning functionality into a morning "fluff" function as a hacky workaround to have the spawning happen _after_ the vanilla bug occurs.